### PR TITLE
Feat/persistent service dependencies validation

### DIFF
--- a/Runtime/LnxInit/Exceptions/InvalidAutoAddTargetException.cs
+++ b/Runtime/LnxInit/Exceptions/InvalidAutoAddTargetException.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace LnxArch
+{
+    [Serializable]
+    public class InvalidAutoAddTargetException : Exception
+    {
+        public InvalidAutoAddTargetException()
+        {
+        }
+
+        public InvalidAutoAddTargetException(string message) : base(message)
+        {
+        }
+
+        public InvalidAutoAddTargetException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected InvalidAutoAddTargetException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Runtime/LnxInit/Exceptions/InvalidDepedencyForPersistentServiceException.cs
+++ b/Runtime/LnxInit/Exceptions/InvalidDepedencyForPersistentServiceException.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace LnxArch
+{
+    [Serializable]
+    public class InvalidDepedencyForPersistentServiceException : Exception
+    {
+        private readonly InitMethodParameter initParam;
+
+        public InvalidDepedencyForPersistentServiceException()
+        {
+        }
+
+        public InvalidDepedencyForPersistentServiceException(InitMethodParameter initParam)
+        : base($"{initParam.ToHumanName()}: Persistent services can't depend on non-persistent services unless they have AutoAdd enabled.")
+        {
+            this.initParam = initParam;
+        }
+
+        public InvalidDepedencyForPersistentServiceException(string message) : base(message)
+        {
+        }
+
+        public InvalidDepedencyForPersistentServiceException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected InvalidDepedencyForPersistentServiceException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Runtime/LnxInit/Exceptions/InvalidDepedencyForPersistentServiceException.cs.meta
+++ b/Runtime/LnxInit/Exceptions/InvalidDepedencyForPersistentServiceException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97076bafe5d9a3546b394eb539f419a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/LnxInit/Preprocessing/TypesPreProcessor.cs
+++ b/Runtime/LnxInit/Preprocessing/TypesPreProcessor.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization;
 
 namespace LnxArch
 {
@@ -160,26 +159,6 @@ namespace LnxArch
 
                 throw new InvalidDepedencyForPersistentServiceException(initParam);
             }
-        }
-    }
-
-    [Serializable]
-    public class InvalidAutoAddTargetException : Exception
-    {
-        public InvalidAutoAddTargetException()
-        {
-        }
-
-        public InvalidAutoAddTargetException(string message) : base(message)
-        {
-        }
-
-        public InvalidAutoAddTargetException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        protected InvalidAutoAddTargetException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
         }
     }
 }


### PR DESCRIPTION
Persistent services can't depend on non-persistent services since the references will be lost once the scene changes.