### PR TITLE
Bugfix/auto add creates local gameobject

### DIFF
--- a/Runtime/AutoAdd/Attributes/LnxAutoAddAttribute.cs
+++ b/Runtime/AutoAdd/Attributes/LnxAutoAddAttribute.cs
@@ -6,7 +6,7 @@ namespace LnxArch
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Parameter)]
     public class LnxAutoAddAttribute : Attribute
     {
-        public AutoAddTarget Target { get; set; } = AutoAddTarget.Local;
+        public AutoAddTarget Target { get; set; } = AutoAddTarget.Entity;
 
         public static LnxAutoAddAttribute GetFrom(Type type)
         {

--- a/Runtime/AutoAdd/Execution/OwnerLookupEntity.cs
+++ b/Runtime/AutoAdd/Execution/OwnerLookupEntity.cs
@@ -5,9 +5,12 @@ namespace LnxArch
 {
     public class OwnerLookupEntity : IOwnerLookup
     {
-        public GameObject Fetch(MonoBehaviour dependencyHolder, Type _)
+        public GameObject Fetch(MonoBehaviour dependencyHolder, Type componentType)
         {
-            return LnxEntity.FetchEntityOf(dependencyHolder).gameObject;
+            LnxEntity entity = LnxEntity.FetchEntityOf(dependencyHolder);
+            GameObject obj = new($"{componentType.Name} [LnxAutoAdd]");
+            obj.transform.SetParent(entity.transform);
+            return obj;
         }
     }
 }

--- a/Runtime/AutoAdd/Execution/OwnerLookupLocal.cs
+++ b/Runtime/AutoAdd/Execution/OwnerLookupLocal.cs
@@ -5,9 +5,11 @@ namespace LnxArch
 {
     public class OwnerLookupLocal : IOwnerLookup
     {
-        public GameObject Fetch(MonoBehaviour dependencyHolder, Type _)
+        public GameObject Fetch(MonoBehaviour dependencyHolder, Type componentType)
         {
-            return dependencyHolder.gameObject;
+            GameObject obj = new($"{componentType.Name} [LnxAutoAdd]");
+            obj.transform.SetParent(dependencyHolder.transform);
+            return obj;
         }
     }
 }

--- a/Runtime/AutoAdd/Execution/OwnerLookupService.cs
+++ b/Runtime/AutoAdd/Execution/OwnerLookupService.cs
@@ -7,7 +7,7 @@ namespace LnxArch
     {
         public GameObject Fetch(MonoBehaviour _, Type componentType)
         {
-            return new($"{componentType.Name} [LnxService - AutoInstantiated]");
+            return new($"{componentType.Name} [LnxService - AutoAdd]");
         }
     }
 }

--- a/Runtime/AutoAdd/Execution/SimpleAutoAdder.cs
+++ b/Runtime/AutoAdd/Execution/SimpleAutoAdder.cs
@@ -7,7 +7,11 @@ namespace LnxArch
     {
         public MonoBehaviour AddOn(GameObject owner, Type componentType)
         {
-            return (MonoBehaviour) owner.AddComponent(componentType);
+            owner.SetActive(false);
+            MonoBehaviour behaviour = (MonoBehaviour) owner.AddComponent(componentType);
+            InitService.Instance.InitBehaviour(behaviour);
+            owner.SetActive(true);
+            return behaviour;
         }
     }
 }


### PR DESCRIPTION
**Problem**
When `AutoAdd` a component, AddComponent calls its Awake before Init methods are called.

**Fix**
Instead of adding to the local object, AutoAdd now creates a child object on the local object, so it can disable it before adding, that way I can call the Init methods before enabling the object, which will call Awake and OnEnable.

**Extras**
* Default AutoAdd target is Entity. AutoAdd now creates a new object, I think it'll be better to create it by default on its entity, instead of the local object, since, if the local object is intended to move, it'll be one more transform for the engine to move.