### PR TITLE
Creates LnxEvent and LnxEventListener abstract classes

### DIFF
--- a/Runtime/LnxEvent.meta
+++ b/Runtime/LnxEvent.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 60b323022a76f404ba2f733d68ab60b7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/LnxEvent/LnxEvent.cs
+++ b/Runtime/LnxEvent/LnxEvent.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+using System.Collections.Generic;
+using UnityEngine.Events;
+
+namespace LnxArch
+{
+    [LnxService]
+    public abstract class LnxEvent<TEvent, TArgs> : MonoBehaviour
+    where TEvent : LnxEvent<TEvent, TArgs>
+    {
+        private HashSet<LnxEventListener<TEvent, TArgs>> _listeners = new();
+
+        public void Trigger(object sender, TArgs args)
+        {
+            foreach (var listener in _listeners)
+            {
+                listener.Trigger(sender, args);
+            }
+        }
+
+        internal void Subscribe(LnxEventListener<TEvent, TArgs> listener)
+        {
+            _listeners.Add(listener);
+        }
+
+        internal void Unsubscribe(LnxEventListener<TEvent, TArgs> listener)
+        {
+            _listeners.Remove(listener);
+        }
+
+        // TODO: Inspector button to trigger
+    }
+}

--- a/Runtime/LnxEvent/LnxEvent.cs.meta
+++ b/Runtime/LnxEvent/LnxEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd398655cd108de429ec177c01dfd02d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/LnxEvent/LnxEventListener.cs
+++ b/Runtime/LnxEvent/LnxEventListener.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+using System;
+
+namespace LnxArch
+{
+    [LnxAutoAdd]
+    public abstract class LnxEventListener<TEvent, TArgs> : MonoBehaviour
+    where TEvent : LnxEvent<TEvent, TArgs>
+    {
+        public EventHandler<TArgs> OnTrigger;
+        private TEvent _event;
+
+        [LnxInit]
+        protected void Init(TEvent lnxEvent)
+        {
+            Debug.Log($"[LnxEventListener] Init {this} with {lnxEvent}");
+            _event = lnxEvent;
+            _event.Subscribe(this);
+        }
+
+        private void OnEnable()
+        {
+            Debug.Log($"[OnEnable] Subscribing {this} to {_event}");
+            _event.Subscribe(this);
+        }
+
+        private void OnDisable()
+        {
+            Debug.Log($"[OnDisable] Unsubscribing {this} from {_event}");
+            _event.Unsubscribe(this);
+        }
+
+        internal void Trigger(object sender, TArgs args)
+        {
+            OnTrigger?.Invoke(sender, args);
+        }
+    }
+}

--- a/Runtime/LnxEvent/LnxEventListener.cs.meta
+++ b/Runtime/LnxEvent/LnxEventListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f77c2cd00731ae458f0cb944e6e7dfc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Creates `LnxEvent<TEvent, TArgs>`, a LnxService meant to be an alternative way of handle communication between different systems.
  * As it is an LnxService, it is auto added by default when received by parameter and it can also be persistent between scenes by adding `[LnxService(Persistent=True)]` at the top of a specific event.
* Creates `LnxEventListener<TEvent, TArgs>`, a common MonoBehaviour that can be used to listen to LnxEvents.
  * It has [LnxAutoAdd] by default, so you don't need to add it to the entity manually.

Quick usage example:
```
// Declaring you new Event
[System.Serializable]
public class WonEventArgs
{
    public int Score { get; set; }
}

public class WonEvent : LnxEvent<WonEvent, WonEventArgs>
{
}

public class WonEventListener : LnxEventListener<WonEvent, WonEventArgs>
{
}

// Using the event by a client
// Notice that the MonoBehaviours above don't need to be added to any game object, they'll be added automatically by LnxArch when calling the Init methods.
public class ClientWonTriggerer : MonoBehaviour
{
    private WonEvent _wonEvent;

    [LnxInit]
    private void Init(WonEvent wonEvent)
    {
        _wonEvent = wonEvent;
    }

    [Button]
    private void Trigger(int score = 100)
    {
        Debug.Log($"[ClientWonTriggerer] Triggering {_wonEvent} with score {score}");
        _wonEvent.Trigger(this, new WonEventArgs {Score = score});
    }
}

public class ClientWonReceiver : MonoBehaviour
{
    [LnxInit]
    private void Init(WonEventListener listener)
    {
        listener.OnTrigger += OnTrigger;
    }

    private void OnTrigger(object sender, WonEventArgs args)
    {
        Debug.Log($"[ClientWonReceiver] {sender} won with score {args.Score}");
    }
}
```